### PR TITLE
Updated rp-basic-ensemble.py example

### DIFF
--- a/docker/example-complete.dockerfile
+++ b/docker/example-complete.dockerfile
@@ -103,6 +103,11 @@ USER rp
 ARG GMXAPI_REF="gmxapi"
 ARG GROMACS_SUFFIX=""
 # Alternative: --build-arg GROMACS_SUFFIX="_mpi"
+# WARNING: MPI may have limited utility in this image.
+# RP may not work right for `local` (fork-based) task launch
+# in an environment that may have imported mpi4py,
+# and there is no `sshd` for alternative launch methods.
+# See https://github.com/SCALE-MS/scale-ms/issues/312
 RUN . $RPVENV/gromacs$GROMACS_SUFFIX/bin/GMXRC && HOME=/home/rp $RPVENV/bin/pip install --no-cache-dir --upgrade $GMXAPI_REF
 
 # Use a custom definition of `local.localhost`.

--- a/docker/example-complete.dockerfile
+++ b/docker/example-complete.dockerfile
@@ -88,7 +88,7 @@
 #     docker exec -ti -u rp -e HOME=/home/rp workshop-example bash -c ". rp-venv/bin/activate && python -m pytest scalems-workshop/external/scale-ms/tests --rp-resource local.localhost --rp-venv \$VIRTUAL_ENV"
 #     docker exec -ti -u rp -e HOME=/home/rp workshop-example bash -c ". rp-venv/bin/activate && python -m scalems.radical --resource=local.localhost --venv /home/rp/rp-venv scalems-workshop/external/scale-ms/examples/basic/echo.py hi there"
 #     docker exec -ti -u rp -e HOME=/home/rp workshop-example bash -c ". rp-venv/bin/activate && python scalems-workshop/external/scale-ms/examples/basic_pipeline/echo-pipeline.py  --resource=local.localhost --venv /home/rp/rp-venv -o stdout.txt hi there && cat stdout.txt"
-#     docker exec -ti -u rp -e HOME=/home/rp workshop-example bash -c ". rp-venv/bin/activate && python scalems-workshop/examples/basic_ensemble/rp_basic_ensemble.py  --resource=local.localhost --venv /home/rp/rp-venv --pilot-option cores=4 --cores-per-sim 2 --size 2 --maxh 0.01"
+#     docker exec -ti -u rp -e HOME=/home/rp workshop-example bash -c ". rp-venv/bin/activate && python scalems-workshop/examples/basic_ensemble/rp_basic_ensemble.py  --resource=local.localhost --venv /home/rp/rp-venv --pilot-option cores=4 --omp-threads-per-sim 2 --size 2 --mdrun-arg maxh 0.01"
 #     docker kill workshop-example
 
 # Prerequisite: build base images from https://github.com/SCALE-MS/scale-ms/tree/master/docker

--- a/examples/basic_ensemble/rp_basic_ensemble.py
+++ b/examples/basic_ensemble/rp_basic_ensemble.py
@@ -43,12 +43,16 @@ For MPI GROMACS::
 
     python rp_basic_ensemble.py \
         --resource local.localhost \
-        --access local \
+        --access ssh \
         --venv $VIRTUAL_ENV \
         --pilot-option cores=4 \
         --procs-per-sim 2 \
         --size 2 \
         --mdrun-arg maxh 1.0
+
+Note that RP access schemes based on forking the Python interpreter may not work
+right with MPI-enabled tasks. Check the resource definition and prefer an access
+scheme that uses ``ssh`` or a job management system, like ``slurm``.
 
 """
 from __future__ import annotations

--- a/examples/basic_ensemble/rp_basic_ensemble.py
+++ b/examples/basic_ensemble/rp_basic_ensemble.py
@@ -21,8 +21,8 @@ For thread-MPI gromacs, run::
         --pilot-option cores=4 \
         --procs-per-sim 1 \
         --threads-per-sim 2 \
-        --mdrun-arg "-nt" 2 \
-        --mdrun-arg "-ntomp" 1 \
+        --mdrun-arg nt 2 \
+        --mdrun-arg ntomp 1 \
         --size 2 \
         --mdrun-arg maxh 1.0
 
@@ -35,7 +35,7 @@ or::
         --pilot-option cores=4 \
         --procs-per-sim 1 \
         --threads-per-sim 2 \
-        --mdrun-arg "-nt" 2 \
+        --mdrun-arg nt 2 \
         --size 2 \
         --mdrun-arg maxh 1.0
 
@@ -94,7 +94,7 @@ async def main(
 
     input_dir: Path = config.inputs
     ensemble_size: int = config.size
-    mdrun_args = {opt[0]: list(opt[1:]) for opt in config.mdrun_args}
+    mdrun_args = {opt[0]: " ".join(opt[1:]) for opt in config.mdrun_args}
 
     commandline = [
         gmx.commandline.cli_executable(),

--- a/examples/basic_ensemble/rp_basic_ensemble.py
+++ b/examples/basic_ensemble/rp_basic_ensemble.py
@@ -9,17 +9,46 @@ tasks is under investigation.
 
 The *cores-per-sim* must not exceed the cores available to the pilot.
 
-For example, for an ensemble of size 2, activate your gmxapi Python virtual
-environment and run::
+For example, for an ensemble of size 2, and 2 cores per simulation,
+activate your gmxapi Python virtual environment.
+
+For thread-MPI gromacs, run::
 
     python rp_basic_ensemble.py \
         --resource local.localhost \
         --access local \
         --venv $VIRTUAL_ENV \
         --pilot-option cores=4 \
-        --cores-per-sim 2 \
+        --procs-per-sim 1 \
+        --threads-per-sim 2 \
+        --mdrun-arg "-nt" 2 \
+        --mdrun-arg "-ntomp" 1 \
         --size 2 \
-        --maxh 1.0
+        --mdrun-arg maxh 1.0
+
+or::
+
+    python rp_basic_ensemble.py \
+        --resource local.localhost \
+        --access local \
+        --venv $VIRTUAL_ENV \
+        --pilot-option cores=4 \
+        --procs-per-sim 1 \
+        --threads-per-sim 2 \
+        --mdrun-arg "-nt" 2 \
+        --size 2 \
+        --mdrun-arg maxh 1.0
+
+For MPI GROMACS::
+
+    python rp_basic_ensemble.py \
+        --resource local.localhost \
+        --access local \
+        --venv $VIRTUAL_ENV \
+        --pilot-option cores=4 \
+        --procs-per-sim 2 \
+        --size 2 \
+        --mdrun-arg maxh 1.0
 
 """
 from __future__ import annotations
@@ -40,21 +69,22 @@ import scalems.workflow
 
 class MDRunResult(typing.TypedDict):
     """Return type for the MDRun Command."""
+
     trajectory: str
     directory: str
 
 
-async def main(*, input_dir: Path, maxh: float, ensemble_size: int, threads_per_rank: int, manager: scalems.workflow.WorkflowManager, label: str) -> tuple[MDRunResult]:
+async def main(
+    *, config: argparse.Namespace, manager: scalems.workflow.WorkflowManager, label: str
+) -> tuple[MDRunResult]:
     """Gromacs simulation on ensemble input
 
     Call the GROMACS MD preprocessor to create a simulation input file. Declare an
     ensemble simulation workflow starting from the single input file.
 
     Args:
-        input_dir: path to the fs-peptide input files
-        maxh: maximum wall time for the simulations
-        ensemble_size: number of independent trajectories
-        threads_per_rank: CPU threads per simulation ('-nt' argument)
+        config: namespace or named tuple with configuration values. (Refer to the argparse parser.)
+        manager: an active scalems WorkflowManager instance.
 
     Returns:
         Trajectory output. (list, if ensemble simulation)
@@ -62,40 +92,67 @@ async def main(*, input_dir: Path, maxh: float, ensemble_size: int, threads_per_
     import gmxapi as gmx
     import scalems_workshop as workshop
 
+    input_dir: Path = config.inputs
+    ensemble_size: int = config.size
+    mdrun_args = {opt[0]: list(opt[1:]) for opt in config.mdrun_args}
+
     commandline = [
-        gmx.commandline.cli_executable(), 'pdb2gmx', '-ff', 'amber99sb-ildn', '-water', 'tip3p',
-        '-f', os.path.join(input_dir, 'start0.pdb'),
-        '-p', workshop.output_file('topol.top'),
-        '-i', workshop.output_file('posre.itp'),
-        '-o', workshop.output_file('conf.gro')
+        gmx.commandline.cli_executable(),
+        "pdb2gmx",
+        "-ff",
+        "amber99sb-ildn",
+        "-water",
+        "tip3p",
+        "-f",
+        os.path.join(input_dir, "start0.pdb"),
+        "-p",
+        workshop.output_file("topol.top"),
+        "-i",
+        workshop.output_file("posre.itp"),
+        "-o",
+        workshop.output_file("conf.gro"),
     ]
     make_top = workshop.executable(commandline)
 
     # make array of inputs
     commandline = [
         gmx.commandline.cli_executable(),
-        'grompp',
-        '-f', os.path.join(input_dir, 'grompp.mdp'),
+        "grompp",
+        "-f",
+        os.path.join(input_dir, "grompp.mdp"),
         # TODO: executable task output proxy
         # '-c', make_top.output_file['conf.gro'],
         # '-p', make_top.output_file['topol.top'],
-        '-c', make_top.output.file['-o'],
-        '-p', make_top.output.file['-p'],
-        '-o', workshop.output_file('run.tpr', label='simulation_input')
+        "-c",
+        make_top.output.file["-o"],
+        "-p",
+        make_top.output.file["-p"],
+        "-o",
+        workshop.output_file("run.tpr", label="simulation_input"),
     ]
     grompp = workshop.executable([commandline])
 
     # TODO: executable task output proxy
     # tpr_input = grompp.output_file['simulation_input']
-    tpr_input = grompp.output.file['-o'].result()
+    tpr_input = grompp.output.file["-o"].result()
 
     session: scalems.radical.runtime.RPDispatchingExecutor
     async with manager.dispatch() as session:
         simulations = tuple(
-            MDRun(tpr_input, maxh=maxh, threads_per_sim=threads_per_rank, manager=manager, dispatcher=session,
-                  label=f"{label}-{i}") for i in range(ensemble_size)
+            MDRun(
+                tpr_input,
+                runtime_args=mdrun_args,
+                task_ranks=config.procs_per_sim,
+                task_cores_per_rank=config.threads_per_sim,
+                manager=manager,
+                dispatcher=session,
+                label=f"{label}-{i}",
+            )
+            for i in range(ensemble_size)
         )
-        futures = tuple(asyncio.create_task(md.result(), name=md.label) for md in simulations)
+        futures = tuple(
+            asyncio.create_task(md.result(), name=md.label) for md in simulations
+        )
         for future in futures:
             future.add_done_callback(lambda x: print(f"Task done: {repr(x)}."))
         return await asyncio.gather(*futures)
@@ -104,20 +161,36 @@ async def main(*, input_dir: Path, maxh: float, ensemble_size: int, threads_per_
 class MDRun:
     """Instance of a simulation Command."""
 
-    def __init__(self, input, *, maxh: float, threads_per_sim: int, label: str,
-            manager: scalems.workflow.WorkflowManager, dispatcher: scalems.radical.runtime.RPDispatchingExecutor, ):
+    def __init__(
+        self,
+        input,
+        *,
+        label: str,
+        runtime_args: dict,
+        task_ranks: int,
+        task_cores_per_rank: int,
+        manager: scalems.workflow.WorkflowManager,
+        dispatcher: scalems.radical.runtime.RPDispatchingExecutor,
+    ):
         self.label = label
+
         # TODO: Manage input file staging so we don't have to assume localhost.
         args = (input,)
-        kwargs = dict(
-            runtime_args={'-maxh': str(maxh), '-nt': str(threads_per_sim)
-            }
-        )
-        requirements = {"ranks": 1, "cores_per_rank": threads_per_sim, "threading_type": "OpenMP"}
+        kwargs = {"runtime_args": runtime_args.copy()}
+        requirements = {
+            "ranks": task_ranks,
+            "cores_per_rank": task_cores_per_rank,
+            "threading_type": "OpenMP",
+        }
         task_uid = label
         self._call_handle: asyncio.Task[scalems.call._Subprocess] = asyncio.create_task(
             scalems.call.function_call_to_subprocess(
-                func=self._func, label=task_uid, args=args, kwargs=kwargs, manager=manager, requirements=requirements
+                func=self._func,
+                label=task_uid,
+                args=args,
+                kwargs=kwargs,
+                manager=manager,
+                requirements=requirements,
             )
         )
         self._dispatcher = dispatcher
@@ -126,6 +199,7 @@ class MDRun:
     def _func(simulation_input, *, runtime_args=None):
         """Task implementation."""
         from gmxapi import mdrun
+
         if runtime_args is None:
             runtime_args = {}
         md = mdrun(simulation_input, runtime_args=runtime_args)
@@ -136,12 +210,16 @@ class MDRun:
         # Wait for input preparation
         call_handle = await self._call_handle
         rp_task_result_future = asyncio.create_task(
-            scalems.radical.runtime.subprocess_to_rp_task(call_handle, dispatcher=self._dispatcher)
+            scalems.radical.runtime.subprocess_to_rp_task(
+                call_handle, dispatcher=self._dispatcher
+            )
         )
         # Wait for submission and completion
         rp_task_result = await rp_task_result_future
         result_future = asyncio.create_task(
-            scalems.radical.runtime.wrapped_function_result_from_rp_task(call_handle, rp_task_result)
+            scalems.radical.runtime.wrapped_function_result_from_rp_task(
+                call_handle, rp_task_result
+            )
         )
         # Wait for results staging.
         result: scalems.call.CallResult = await result_future
@@ -150,21 +228,60 @@ class MDRun:
         return {"trajectory": result.return_value, "directory": result.directory}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import scalems.radical
+
     # Set up a command line argument processor for our script.
     # Inherit from the backend parser so that `parse_known_args` can handle positional arguments the way we want.
-    parser = argparse.ArgumentParser(parents=[scalems.radical.parser], add_help=False)
+    parser = argparse.ArgumentParser(
+        parents=[scalems.radical.runtime.parser()],
+        add_help=True,
+        description="Warning: The automatically generated usage information is not quite right, "
+        "pending normalization with the scalems backend invocation. "
+        "Refer to the docstring in the file for details.",
+    )
 
-    parser.add_argument('--cores-per-sim', type=int, help='The total number of cores allocated for the job.')
-    parser.add_argument('--maxh', type=float, default=0.01, help='Maximum time for a single simulation in this module.')
-    parser.add_argument('--inputs', type=Path,
-        default=Path(__file__).resolve().parent.parent.parent / 'input_files' / 'fs-peptide',
-        help='Directory containing fs-peptide input files.')
+    parser.add_argument(
+        "--procs-per-sim",
+        type=int,
+        default=1,
+        help="Processes (MPI ranks) per simulation task. (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--threads-per-sim",
+        type=int,
+        default=1,
+        help="OMP_NUM_THREADS in simulation processes. (default: %(default)s)",
+    )
+    # I wasn't able to quickly find a user-friendly way to process arbitrarily multi-valued
+    # arguments that, themselves, look like arguments that would terminate a `nargs="*"` stream.
+    parser.add_argument(
+        "--mdrun-arg",
+        dest="mdrun_args",
+        action="append",
+        default=[],
+        nargs="*",
+        help="Option flag (with the leading '-' removed)"
+        " and value(s) to be passed to the GROMACS simulator. Use once per option.",
+        metavar="OPTION VAL1 [VAL2]",
+    )
+    parser.add_argument(
+        "--inputs",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent.parent
+        / "input_files"
+        / "fs-peptide",
+        help="Directory containing fs-peptide input files. (default: %(default)s)",
+    )
     # parser.add_argument('--log-level', default='ERROR',
     #     help='Minimum log level to handle for the Python "logging" module. (See '
     #          'https://docs.python.org/3/library/logging.html#logging-levels)')
-    parser.add_argument("--size", type=int, default=1, help="Ensemble size: number of parallel pipelines.")
+    parser.add_argument(
+        "--size",
+        type=int,
+        default=1,
+        help="Ensemble size: number of parallel pipelines. (default: %(default)s)",
+    )
 
     # Work around some quirks: we are using the parser that normally assumes the
     # backend from the command line. We can switch back to the `-m scalems.radical`
@@ -184,27 +301,23 @@ if __name__ == '__main__':
     if level is not None:
         character_stream = logging.StreamHandler()
         character_stream.setLevel(level)
-        formatter = logging.Formatter("%(asctime)s-%(name)s:%(lineno)d-%(levelname)s - %(message)s")
+        formatter = logging.Formatter(
+            "%(asctime)s-%(name)s:%(lineno)d-%(levelname)s - %(message)s"
+        )
         character_stream.setFormatter(formatter)
         logging.basicConfig(level=level, handlers=[character_stream])
 
-    logging.info(f'Input directory set to {config.inputs}.')
+    logging.info(f"Input directory set to {config.inputs}.")
 
     # Call the main work.
     manager = scalems.radical.workflow_manager(asyncio.get_event_loop())
     with scalems.workflow.scope(manager, close_on_exit=True):
         md_outputs = asyncio.run(
-            main(
-                input_dir=config.inputs,
-                maxh=config.maxh,
-                threads_per_rank=config.cores_per_sim,
-                manager=manager,
-                ensemble_size=config.size,
-                label="rp-basic-ensemble"),
-            debug=debug)
+            main(config=config, manager=manager, label="rp-basic-ensemble"), debug=debug
+        )
 
     trajectory = [md["trajectory"] for md in md_outputs]
     directory = [md["directory"] for md in md_outputs]
 
     for i, out in enumerate(zip(trajectory, directory)):
-        print(f'Trajectory {i}: {out[0]}. Directory archive (zip file) {i}: {out[1]}')
+        print(f"Trajectory {i}: {out[0]}. Directory archive (zip file) {i}: {out[1]}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ mpi4py
 numpy
 pip
 radical.pilot>=1.20
-scalems
+scalems>=0.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 python_requires = >=3.8
@@ -26,7 +27,7 @@ install_requires =
     numpy
     packaging
     radical.pilot
-    scalems
+    scalems>=0.0.0
 
 tests_require =
     build


### PR DESCRIPTION
## Summary

The original example had mdrun arguments hard coded in the python script that made the script only valid for thread-MPI GROMACS installations.

* Add some flexibility to account for different possible GROMACS back-end.
* Defer GROMACS resource assignment flags to user, via new `--mdrun-arg`.

## Validation

In a Docker container with 4 cores, I installed gmxapi 0.4.0 with an MPI-enabled GROMACS 2023, and ran the following.

    python rp_basic_ensemble.py --resource docker.login --access ssh --venv $VIRTUAL_ENV/ --pilot-option cores=4 --procs-per-sim 2 --size 2 --mdrun-arg maxh 0.01 --log-level DEBUG

Based on the terminal output, I then checked the MD log to confirm the simulation ran successfully with 2 MPI ranks.

    cat  /home/rp/radical.pilot.sandbox/rp.session.2c419e24-bcec-11ed-9770-0242ac120003/pilot.e6f81a7e-d847-4e28-810e-24c632616aef/rp-basic-ensemble-1/mdrun_6d00f4b07eabc852c23b016d1c2ca339_i0_0/md.log