### PR TITLE
Migrate rp-basic-ensemble example to raptor back end.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/scale-ms"]
 	path = external/scale-ms
 	url = git@github.com:SCALE-MS/scale-ms.git
-	branch = sms326-executable-devel
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/scale-ms"]
 	path = external/scale-ms
 	url = git@github.com:SCALE-MS/scale-ms.git
-	branch = master
+	branch = sms326-executable-devel

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,6 +45,44 @@ docker run --rm -ti -u rp -e HOME=/home/rp scalems/example-complete bash -c \
 '. rp-venv/bin/activate; mkdir exercise1 && cd exercise1 && mpiexec -n 2 `which python` -m mpi4py ~/scalems-workshop/examples/basic_ensemble/basic_ensemble.py --maxh 0.001'
 ```
 
+### Example 01.1
+
+Run a simulation or array of simulations from a script.
+
+Note that the raptor task and worker will consume at least 2 cores from the pilot allocation.
+
+Replace `size` with an appropriate ensemble size. Remove or update the `maxh` *mdrun-arg* for desired simulation length.
+
+```shell
+cd external/scale-ms/docker
+# Use the following line if and only if you need a non-default gromacs build.
+docker compose build --build-arg GROMACS_SUFFIX=_mpi login compute
+docker compose up -d
+docker compose cp ../../../ login:/home/rp/
+docker compose exec login bash -c 'chown -R rp:radical /home/rp'
+docker compose exec -ti -u rp -e HOME=/home/rp login bash
+```
+
+Then, in the container environment:
+
+```shell
+. rp-venv/bin/activate
+pip install -r scalems-workshop/external/scale-ms/requirements-testing.txt
+pip install -e scalems-workshop/external/scale-ms
+pip install -e scalems-workshop
+mkdir exercise1
+cd exercise1
+python ~/scalems-workshop/examples/basic_ensemble/rp_basic_ensemble.py \
+  --resource docker.login \
+  --access ssh \
+  --venv $VIRTUAL_ENV \
+  --procs-per-sim 1 \
+  --pilot-option cores=4 \
+  --size 2 \
+  --mdrun-arg maxh 0.001 \
+  --enable-raptor
+```
+
 ### Example 02
 
 Run a simulation-ensemble-analysis loop from a script.

--- a/docker/resource_local.json
+++ b/docker/resource_local.json
@@ -22,7 +22,7 @@
     "virtenv_mode": "use",
     "virtenv": "/home/rp/rp-venv",
     "python_dist": "default",
-    "cores_per_node": 4,
+    "cores_per_node": 8,
     "gpus_per_node": 0,
     "lfs_path_per_node": "/tmp",
     "lfs_size_per_node": 1024,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ jupyter
 mpi4py
 numpy
 pip
-git+https://github.com/radical-cybertools/radical.pilot.git@feature/raptor_api_2#egg=radical.pilot
-git+https://github.com/SCALE-MS/scale-ms.git@sms253-devel
+radical.pilot>=1.33
+scalems>=0.0.1b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ jupyter
 mpi4py
 numpy
 pip
-radical.pilot>=1.20
-scalems>=0.0.0
+git+https://github.com/radical-cybertools/radical.pilot.git@feature/raptor_api_2#egg=radical.pilot
+git+https://github.com/SCALE-MS/scale-ms.git@sms253-devel


### PR DESCRIPTION
Minor changes for testing against the updated rp raptor backend, tests, and documentation.

Note that, for scalems 0.0.1, the user needs to account for an extra core, each, for the raptor scheduler and worker tasks. Make sure that the requested pilot cores are at least 2 greater than any task requirements. See https://github.com/SCALE-MS/scale-ms/issues/335

Resolves #8 